### PR TITLE
Update mirror-k8s-repos.sh

### DIFF
--- a/scripts/mirror-k8s-repos.sh
+++ b/scripts/mirror-k8s-repos.sh
@@ -15,7 +15,7 @@ get_all_tgzs() {
     pushd mirror/
     for tgz in $tgzs; do
         if [ ! -f "${tgz##*/}" ]; then
-            wget $tgz
+            wget $repo_url/$tgz
         fi
     done
     popd


### PR DESCRIPTION
Fix the wget line that downloads the actual charts.

Previously this just passed a filename (not a url) to wget. That certainly doesn't do anything on /my/ version of wget.